### PR TITLE
fix: remove exhaustive check in assistant part handling to support reasoning part

### DIFF
--- a/src/convert-to-qwen-chat-messages.test.ts
+++ b/src/convert-to-qwen-chat-messages.test.ts
@@ -123,6 +123,43 @@ describe("tool calls", () => {
   })
 })
 
+describe("assistant messages", () => {
+  it("should convert messages with only a text part to a string content", () => {
+    const result = convertToQwenChatMessages([
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "I'm a helpful assistant." }],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: "I'm a helpful assistant.",
+      },
+    ])
+  })
+
+  it("should convert messages with reasoning parts", () => {
+    const result = convertToQwenChatMessages([
+      {
+        role: "assistant",
+        content: [
+          { type: "reasoning", text: "I'm thinking..." },
+          { type: "text", text: "I'm a helpful assistant." },
+        ],
+      },
+    ])
+
+    expect(result).toEqual([
+      {
+        role: "assistant",
+        content: "I'm a helpful assistant.",
+      },
+    ])
+  })
+})
+
 describe("provider-specific metadata merging", () => {
   it("should merge system message metadata", async () => {
     const result = convertToQwenChatMessages([

--- a/src/convert-to-qwen-chat-messages.ts
+++ b/src/convert-to-qwen-chat-messages.ts
@@ -122,11 +122,6 @@ export function convertToQwenChatMessages(
               })
               break
             }
-            default: {
-              // This branch should never occur.
-              const _exhaustiveCheck: never = part
-              throw new Error(`Unsupported part: ${_exhaustiveCheck}`)
-            }
           }
         }
 


### PR DESCRIPTION
Currently, I am encountering this issue with a deeply thoughtful model on Qwen. After calling MCP, it leads to errors when performing recursive (looped) tool calls.