### PR TITLE
fix: response chunk tool_calls type can be null

### DIFF
--- a/src/qwen-chat-language-model.ts
+++ b/src/qwen-chat-language-model.ts
@@ -731,7 +731,7 @@ function createQwenChatChunkSchema<ERROR_SCHEMA extends z.ZodType>(errorSchema: 
                   z.object({
                     index: z.number(),
                     id: z.string().nullish(),
-                    type: z.literal("function").optional(),
+                    type: z.literal("function").nullish(),
                     function: z.object({
                       name: z.string().nullish(),
                       arguments: z.string().nullish(),


### PR DESCRIPTION
the response chunk tool_calls type can be null, like the example below:

{"id":"0197e439198cd34d34fa957ba43a9ced","object":"chat.completion.chunk","created":1751880636,"model":"Qwen/Qwen2.5-7B-Instruct","choices":[{"index":0,"delta":{"content":null,"reasoning_content":null,"tool_calls":[{"index":0,"id":null,"type":null,"function":{"arguments":" {\""}}]},"finish_reason":null}],"system_fingerprint":"","usage":{"prompt_tokens":294,"completion_tokens":3,"total_tokens":297}}


tested with Qwen/Qwen2.5-7B-Instruct and Qwen/Qwen3-8B