### PR TITLE
chore: set commit message format for version releases

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": false,
+  "commit": "chore: release version %s",
   "fixed": [],
   "linked": [],
   "access": "restricted",


### PR DESCRIPTION
This pull request updates the configuration for Changesets to include a custom commit message format when releasing versions.

* [`.changeset/config.json`](diffhunk://#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L4-R4): Modified the `commit` property to use the custom format `"chore: release version %s"`, replacing the previous `false` value.