### PR TITLE
fix: update commit message format in changeset configuration

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.0.5/schema.json",
   "changelog": "@changesets/cli/changelog",
-  "commit": "chore: release version %s",
+  "commit": false,
   "fixed": [],
   "linked": [],
   "access": "restricted",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,7 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: pnpm ci:release
+          commit: "chore: version packages"  
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This pull request updates the configuration for Changesets and modifies the GitHub Actions workflow for publishing. The most important changes include disabling automatic commit messages in the Changesets configuration and adding a custom commit message in the publishing workflow.

### Changesets configuration updates:
- [`.changeset/config.json`](diffhunk://#diff-ed5b41335ff968c5cfd8035d4b8f8c8c0538b6746182d522adb0312eb9137fc5L4-R4): Disabled automatic commit messages by setting the `commit` option to `false`.

### GitHub Actions workflow updates:
- [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R43): Added a custom commit message ("chore: version packages") to the `changesets/action` step in the publishing workflow.